### PR TITLE
change to have the index in the config be a template string

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,8 +44,7 @@ func main() {
 }
 
 func run(configFile string) {
-	config := new(configuration)
-	err := loadFromFile(configFile, config)
+	config, err := loadFromFile(configFile)
 	if err != nil {
 		log.Fatalf("Failed to load configuation: %s %v", configFile, err)
 	}
@@ -57,7 +56,6 @@ func run(configFile string) {
 
 	rootLog.Info("Configured - starting to connect and consume")
 
-	// connect to ES
 	clientChannel := make(chan payload)
 	stats := new(counters)
 	go reportStats(config.ReportSec, config, stats, rootLog)

--- a/script/test.sh
+++ b/script/test.sh
@@ -3,7 +3,6 @@
 set -e
 set -x
 
-mkdir -p vendor
 glide --no-color install
 go test $(go list ./... | grep -v /vendor/)
 go build -o $1


### PR DESCRIPTION
I intend on rolling the logs in elasticsearch daily. This will make it so we can purge on a much more granular level. 

what it will become: `logs_{{ .Year }}_{{ .Month }}_{{ .Day }}` which will be things like: `logs_2016_July_12`. 
